### PR TITLE
chore: update mainnet prod genesis block to 17507487

### DIFF
--- a/src/shared/abi/prod.v4.mainnet.abi.json
+++ b/src/shared/abi/prod.v4.mainnet.abi.json
@@ -1,7 +1,7 @@
 {
   "contractAddress": "0xDD9BC35aE942eF0cFa76930954a156B3fF30a4E1",
   "tokenAddress": "0x9D65fF81a3c488d585bBfb0Bfe3c7707c7917f54",
-  "genesisBlock": 17428695,
+  "genesisBlock": 17507487,
   "abi": [
   {
     "inputs": [],

--- a/src_ssv/shared/abi/prod.v4.mainnet.abi.json
+++ b/src_ssv/shared/abi/prod.v4.mainnet.abi.json
@@ -1,7 +1,7 @@
 {
   "contractAddress": "0xDD9BC35aE942eF0cFa76930954a156B3fF30a4E1",
   "tokenAddress": "0x9D65fF81a3c488d585bBfb0Bfe3c7707c7917f54",
-  "genesisBlock": 17428695,
+  "genesisBlock": 17507487,
   "abi": [
   {
     "inputs": [],


### PR DESCRIPTION
## Summary
- Updates `genesisBlock` in `prod.v4.mainnet.abi.json` from `17428695` to `17507487`

🤖 Generated with [Claude Code](https://claude.com/claude-code)